### PR TITLE
fixing secret SONAR_TOKEN name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run sonar-scanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           sonar-scanner --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
 


### PR DESCRIPTION
As per the official documentation recommends to give SONAR_TOKEN as secret name, it is quite confusing to find it having another name in your example. 

![image](https://user-images.githubusercontent.com/5926779/188690831-b0e7ea6a-cf13-4b55-b16a-748cd80ec439.png)

